### PR TITLE
Bug 1041577: deploy mig-agent

### DIFF
--- a/manifests/relabs-config.pp
+++ b/manifests/relabs-config.pp
@@ -18,6 +18,8 @@ class config inherits config::base {
     $data_server = $puppet_server
     $apt_repo_server = $data_server
 
+    $enable_mig_agent = true
+
     $distinguished_puppetmaster = "relabs-puppet2.relabs.releng.scl3.mozilla.com"
     $puppet_again_repo = "https://hg.mozilla.org/build/puppet/"
 

--- a/modules/config/manifests/base.pp
+++ b/modules/config/manifests/base.pp
@@ -127,6 +127,9 @@ class config::base {
     # between them.
     $node_location = 'unknown'
 
+    # a flag the controls which nodes should install and run MIG Agent
+    $enable_mig_agent = false
+
     ##
     ## users
     ##

--- a/modules/mig/manifests/agent.pp
+++ b/modules/mig/manifests/agent.pp
@@ -1,0 +1,55 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+class mig::agent {
+    include ::config
+    if ($::config::enable_mig_agent) {
+        case $::operatingsystem {
+            'CentOS', 'RedHat': {
+                realize(Packages::Yumrepo['mig-agent'])
+            }
+            'Ubuntu': {
+                realize(Packages::Aptrepo['mig-agent'])
+            }
+        }
+
+        case $::operatingsystem {
+            'CentOS', 'RedHat', 'Ubuntu': {
+                package {
+                    "mig-agent":
+                        ensure => latest,
+                        require => [ File['/etc/mig/mig-agent.cfg'],
+                                     File['/etc/mig/ca.crt'],
+                                     File['/etc/mig/agent.crt'],
+                                     File['/etc/mig/agent.key']
+                                   ];
+                }
+                file {
+                    "/etc/mig/":
+                        ensure => "directory",
+                        owner => "root",
+                        mode => 755;
+                    "/etc/mig/mig-agent.cfg":
+                        content => template("mig/mig-agent.cfg.erb"),
+                        owner => "root",
+                        mode => 600;
+                    "/etc/mig/ca.crt":
+                        content => template("mig/ca.crt.erb"),
+                        owner => "root",
+                        mode => 600;
+                    "/etc/mig/agent.crt":
+                        content => template("mig/agent.crt.erb"),
+                        owner => "root",
+                        mode => 600;
+                    "/etc/mig/agent.key":
+                        content => template("mig/agent.key.erb"),
+                        owner => "root",
+                        mode => 600;
+                }
+            }
+            default: {
+                fail("cannot install on $::operatingsystem")
+            }
+        }
+    }
+}

--- a/modules/mig/templates/agent.crt.erb
+++ b/modules/mig/templates/agent.crt.erb
@@ -1,0 +1,1 @@
+<%= scope.function_secret(['mig_agent_crt']) %>

--- a/modules/mig/templates/agent.key.erb
+++ b/modules/mig/templates/agent.key.erb
@@ -1,0 +1,1 @@
+<%= scope.function_secret(['mig_agent_key']) %>

--- a/modules/mig/templates/ca.crt.erb
+++ b/modules/mig/templates/ca.crt.erb
@@ -1,0 +1,1 @@
+<%= scope.function_secret(['mig_agent_ca_crt']) %>

--- a/modules/mig/templates/mig-agent.cfg.erb
+++ b/modules/mig/templates/mig-agent.cfg.erb
@@ -1,0 +1,24 @@
+[agent]
+    isimmortal      = on
+    installservice  = on
+    relay           = "<%= scope.function_secret(['mig_agent_relay_uri']) %>"
+    socket          = "127.0.0.1:51664"
+    heartbeatfreq   = "30s"
+    moduletimeout   = "300s"
+
+[certs]
+    ca  = "/etc/mig/ca.crt"
+    cert= "/etc/mig/agent.crt"
+    key = "/etc/mig/agent.key"
+
+[logging]
+    mode    = "syslog" ; stdout | file | syslog
+    level   = "info"
+
+; for file logging
+;   file = "mig_scheduler.log"
+
+; for syslog, logs go into local3
+    host   = "localhost"
+    port   = 514
+    protocol = "udp"

--- a/modules/packages/manifests/setup.pp
+++ b/modules/packages/manifests/setup.pp
@@ -56,11 +56,14 @@ class packages::setup {
 
                 "hp-proliantsupportpack":
                     url_path => "repos/yum/mirrors/hp/proliantsupportpack/CentOS/$majorver/$architecture/current";
+
+                "mig-agent":
+                    url_path => "repos/yum/custom/mig-agent/$architecture";
             }
 
             # to flush the metadata cache, increase this value by one (or
             # anything, really, just change it).
-            $repoflag = 16
+            $repoflag = 17
             file {
                 "/etc/.repo-flag":
                     content =>
@@ -146,6 +149,10 @@ class packages::setup {
             @packages::aptrepo {
                 "xorg-edgers":
                     url_path     => "repos/apt/xorg-edgers",
+                    distribution => "${lsbdistcodename}",
+                    components   => ["main"];
+                "mig-agent":
+                    url_path     => "repos/apt/custom/mig-agent",
                     distribution => "${lsbdistcodename}",
                     components   => ["main"];
             }

--- a/modules/toplevel/manifests/base.pp
+++ b/modules/toplevel/manifests/base.pp
@@ -30,6 +30,7 @@ class toplevel::base {
     include needs_reboot::motd
     include collectd
     include instance_metadata
+    include mig::agent
 
     class { 'web_proxy':
         host => $::config::web_proxy_host,


### PR DESCRIPTION
This patch enables provisioning of mig-agent in puppetagain.
I _think_ this is safe to merge as only the relabs nodes will receive the mig-agent configuration, and the relabs puppetmaster has everything it needs. But I would appreciate a round of reviews before merging.

Thanks!
