### PR TITLE
Bug 1309197: Add taskcluster-worker support; p=wcosta/dustin

### DIFF
--- a/manifests/moco-nodes.pp
+++ b/manifests/moco-nodes.pp
@@ -6,6 +6,15 @@
 
 # linux64 and OS X
 
+node /t-yosemite-r7-00[45][0-9]\.test\.releng\.scl3\.mozilla\.com/ {
+    $pin_puppet_server = "releng-puppet2.srv.releng.scl3.mozilla.com"
+    $pin_puppet_env = "dmitchell"
+    $aspects = [ 'low-security' ]
+    $slave_trustlevel = 'try'
+    $taskcluster = true
+    include toplevel::worker::releng::test::gpu
+}
+
 node /t.*-\d+\.test\.releng\.scl3\.mozilla\.com/ {
     # hosts starting with t and ending in -digit.test.releng.scl3.mozilla.com
     $aspects = [ 'low-security' ]

--- a/modules/packages/manifests/mozilla/taskcluster_worker.pp
+++ b/modules/packages/manifests/mozilla/taskcluster_worker.pp
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class packages::mozilla::taskcluster_worker {
+    anchor {
+        'packages::mozilla::taskcluster_worker::begin': ;
+        'packages::mozilla::taskcluster_worker::end': ;
+    }
+
+    $version = '0.0.6'
+
+    # Binaries should be downloaded from
+    # https://github.com/taskcluster/taskcluster-worker/releases/download/${version}/taskcluster-worker-${plat}
+    # to /data/repos/EXEs/taskcluster-worker-${version}-${plat}
+
+    Anchor['packages::mozilla::taskcluster_worker::begin'] ->
+    case $::operatingsystem {
+        Darwin: {
+            file {
+                '/usr/local/bin/taskcluster-worker':
+                    source => "puppet:///repos/EXEs/taskcluster-worker-${version}-darwin-amd64",
+                    mode => 0755,
+                    owner => root,
+                    group => wheel,
+            }
+        }
+        default: {
+            fail("cannot install on $::operatingsystem")
+        }
+    } -> Anchor['packages::mozilla::taskcluster_worker::end']
+}
+

--- a/modules/taskcluster_worker/manifests/init.pp
+++ b/modules/taskcluster_worker/manifests/init.pp
@@ -1,0 +1,35 @@
+class taskcluster_worker {
+    include packages::mozilla::taskcluster_worker
+
+	case $::operatingsystem {
+        Darwin: {
+            $macos_version = regsubst($::macosx_productversion_major, '\.', '-')
+            $taskcluster_client_id = secret('taskcluster_worker_client_id')
+            $taskcluster_access_token = hiera('taskcluster_worker_access_token')
+
+            file { '/Library/LaunchAgents/net.taskcluster.worker.plist':
+                ensure => present,
+                content => template('taskcluster_worker/taskcluster-worker.plist.erb'),
+                mode => 0644,
+                owner => root,
+                group => wheel,
+            }
+            file { '/etc/taskcluster-worker.yml':
+                ensure => present,
+                content => template('taskcluster_worker/taskcluster-worker.yml.erb'),
+                mode => 0644,
+                owner => root,
+                group => wheel,
+            }
+            service { "net.taskcluster.worker":
+                require   => [
+                    File["/Library/LaunchAgents/net.taskcluster.worker.plist"],
+                ],
+                enable    => true;
+            }
+        }
+        default: {
+            fail("cannot install on $::operatingsystem")
+        }
+	}
+}

--- a/modules/taskcluster_worker/templates/taskcluster-worker.plist.erb
+++ b/modules/taskcluster_worker/templates/taskcluster-worker.plist.erb
@@ -1,0 +1,35 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+<%# License, v. 2.0. If a copy of the MPL was not distributed with this
+<%# file, You can obtain one at http://mozilla.org/MPL/2.0/. -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>net.taskcluster.worker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/taskcluster-worker</string>
+        <string>daemon</string>
+        <string>run</string>
+        <string>/etc/taskcluster-worker.yml</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users</string>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>PathState</key>
+        <dict>
+            <!-- start if this file exists (the name is a legacy from buildbot days) -->
+            <key>/var/tmp/semaphore/run-buildbot</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>StandardErrorPath</key>
+    <string>/var/tmp/taskcluster-worker.err</string>
+    <key>StandardOutPath</key>
+    <string>/var/tmp/taskcluster-worker.log</string>
+</dict>
+</plist>

--- a/modules/taskcluster_worker/templates/taskcluster-worker.yml.erb
+++ b/modules/taskcluster_worker/templates/taskcluster-worker.yml.erb
@@ -1,0 +1,48 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+transforms:
+  - env
+  - secrets
+config:
+  capacity:         1
+  credentials:
+    # Create a client with the scope:
+    # assume:project:taskcluster:worker-test-scopes
+    # secrets:get:project/taskcluster/taskcluster-worker/stateless-dns
+    clientId:       <%= @taskcluster_client_id %>
+    accessToken:    <%= @taskcluster_access_token %>
+  provisionerId:    tc-worker-provisioner
+  workerType:       gecko-t-osx-<%= @macos_version %>
+  workerGroup:      macosx-tc-worker
+  workerId:         <%= @hostname %>
+  engine:           macosx
+  engines:
+    macosx:
+      createUser: true
+      sudo: true
+      userGroups: ['staff', 'everyone', 'localaccounts', '_developer', '_lpoperator', 'com.apple.sharepoint.group.1']
+  logLevel:         info
+  plugins:
+    disabled:       ['success', 'interactive']
+  pollingInterval:  10
+  queueBaseUrl:     https://queue.taskcluster.net/v1
+  reclaimOffset:    120
+  temporaryFolder:  /var/tmp/tc-worker-tmp
+  serverIp:           127.0.0.1
+  serverPort:         60000
+  tlsCertificiate:
+    $secret:  project/taskcluster/taskcluster-worker/stateless-dns
+    key:      certificate
+  tlsKey:
+    $secret:  project/taskcluster/taskcluster-worker/stateless-dns
+    key:      tlsKey
+  statelessDNSSecret:
+    $secret:  project/taskcluster/taskcluster-worker/stateless-dns
+    key:      secret
+  statelessDNSDomain:
+    $secret:  project/taskcluster/taskcluster-worker/stateless-dns
+    key:      domain
+  maxLifeCycle:       600
+  minimumDiskSpace:   10000000  # 10 GB
+  minimumMemory:      1000000   # 1 GB

--- a/modules/toplevel/manifests/worker.pp
+++ b/modules/toplevel/manifests/worker.pp
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# All TaskCluster workers are subclasses of this class.
+
+class toplevel::worker inherits toplevel::base {
+    include disableservices::slave
+    include puppet::atboot
+    include sudoers::reboot
+    include users::builder
+
+    # apply tweaks
+    include tweaks::dev_ptmx
+    include tweaks::locale
+
+    case $::operatingsystem {
+        'Darwin': {
+            include users::root::autologin
+        }
+
+        default: {
+            fail("worker not (yet) supported on ${::operatingsystem}")
+        }
+    }
+}

--- a/modules/toplevel/manifests/worker/releng.pp
+++ b/modules/toplevel/manifests/worker/releng.pp
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class toplevel::worker::releng inherits toplevel::worker {
+    include instance_metadata
+    include clean::appstate
+
+    # packages common to all slaves
+    include packages::mozilla::tooltool
+    include packages::wget
+    include packages::mozilla::py27_mercurial
+    # TODO: run mig agent on boot?
+    include mig::agent::daemon
+
+    include taskcluster_worker
+
+    case $::kernel {
+        'Linux': {
+            # authorize aws-manager to reboot instances
+            users::builder::extra_authorized_key {
+                'aws-ssh-key': ;
+            }
+        }
+    }
+
+    # ensure runner is actually disabled, in case this machine was once set up
+    # to run buildbot (temporary)
+    file {
+        "/Library/LaunchAgents/com.mozilla.runner.plist":
+            ensure => absent,
+    }
+}

--- a/modules/toplevel/manifests/worker/releng/test.pp
+++ b/modules/toplevel/manifests/worker/releng/test.pp
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class toplevel::worker::releng::test inherits toplevel::worker::releng {
+    include talos
+    include vnc
+    include ntp::atboot
+    include dirs::builds::hg_shared
+    include dirs::builds::git_shared
+    include dirs::builds::tooltool_cache
+    if ($::operatingsystem != Windows) {
+        include tweaks::fonts
+        include packages::fonts
+        include packages::unzip
+    }
+
+    case $::operatingsystem {
+        "Ubuntu": {
+        }
+        "Darwin": {
+            include tweaks::disable_bonjour
+        }
+        "Windows": {
+            include disableservices::disable_indexing
+            include disableservices::disable_win_defend
+            include disableservices::disable_win_driver_signing
+            include disableservices::disableupdates
+            include packages::mozilla::dumbwin32proc
+            include packages::mozilla::mozilla_maintenance_service
+            include packages::nvidia_drivers
+            include packages::win7sdk
+            include tweaks::disable_desktop_interruption
+            include tweaks::memory_paging
+            include tweaks::sync_logon_scripts
+        }
+    }
+
+    if ($::operatingsystem != Windows) {
+        class {
+            'slave_secrets':
+                slave_type => 'test';
+        }
+    }
+}

--- a/modules/toplevel/manifests/worker/releng/test/gpu.pp
+++ b/modules/toplevel/manifests/worker/releng/test/gpu.pp
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class toplevel::worker::releng::test::gpu inherits toplevel::worker::releng::test {
+    class {
+        gui:
+            on_gpu => true,
+            screen_width => 1600,
+            screen_height => 1200,
+            screen_depth => 32,
+            refresh => 60;
+    }
+}

--- a/modules/users/manifests/builder/autologin.pp
+++ b/modules/users/manifests/builder/autologin.pp
@@ -85,4 +85,14 @@ class users::builder::autologin {
             fail("Don't know how to set up autologin on $::operatingsystem")
         }
     }
+
+    ##
+    # disable account-specific services
+
+    class {
+        'disableservices::user':
+            username => $users::builder::username,
+            group => $users::builder::group,
+            home => $users::builder::home;
+    }
 }

--- a/modules/users/manifests/builder/setup.pp
+++ b/modules/users/manifests/builder/setup.pp
@@ -79,14 +79,4 @@ class users::builder::setup($home, $username, $group) {
             group => $group,
             source => "puppet:///modules/users/screenrc";
     }
-
-    ##
-    # disable account-specific services
-
-    class {
-        'disableservices::user':
-            username => $username,
-            group => $group,
-            home => $home;
-    }
 }

--- a/modules/users/manifests/root/autologin.pp
+++ b/modules/users/manifests/root/autologin.pp
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+class users::root::autologin {
+    include users::root
+
+    case $::operatingsystem {
+        Darwin: {
+            file {
+                # this file contains a lightly obscured copy of the password
+                "/etc/kcpassword":
+                    content => base64decode(secret("root_pw_kcpassword_base64")),
+                    owner => root,
+                    group => wheel,
+                    mode => 600,
+                    show_diff => false;
+            }
+            osxutils::defaults {
+                autoLoginUser:
+                    domain => "/Library/Preferences/com.apple.loginwindow",
+                    key => 'autoLoginUser',
+                    value => $::users::root::username;
+            }
+        }
+        Ubuntu: {
+            # Managed by xvfb/Xsession
+        }
+        default: {
+            fail("Don't know how to set up autologin on $::operatingsystem")
+        }
+    }
+
+    ##
+    # disable account-specific services
+
+    class {
+        'disableservices::user':
+            username => $users::root::username,
+            group => $users::root::group,
+            home => $users::root::home;
+    }
+}


### PR DESCRIPTION
taskcluster-worker runs via a launchd agent. It runs as root because it
needs root access to dscl command.