### PR TITLE
Update dependencies for non-signing server, non-scriptworker machines.

### DIFF
--- a/modules/buildbot_bridge/files/requirements.txt
+++ b/modules/buildbot_bridge/files/requirements.txt
@@ -2,11 +2,11 @@
 requests==2.18.4
 arrow==0.12.1
 taskcluster==3.0.1
-sqlalchemy==1.2.7
-kombu==4.2.0
+sqlalchemy==1.2.8
+kombu==4.2.1
 redo==1.6
 mysql-python==1.2.5
-amqp==2.2.2
+amqp==2.3.2
 python-dateutil==2.7.3
 pytz==2018.4
 six==1.11.0

--- a/modules/buildbot_bridge2/files/requirements.txt
+++ b/modules/buildbot_bridge2/files/requirements.txt
@@ -1,24 +1,25 @@
 # python_version: 36
-aiohttp==1.3.5
+# Held at 1.3.5 because it's not worth upgrading before buildbot dies.
+aiohttp==1.3.5  # pyup: ignore
 appdirs==1.4.3
-arrow==0.10.0
-async-timeout==1.2.0
-chardet==2.3.0
+arrow==0.12.1
+async-timeout==3.0.0
+chardet==3.0.4
 click==6.7
 jsonschema==2.6.0
 mohawk==0.3.4
-multidict==2.1.4
-mysql-connector-python==2.0.4  # puppet: nodownload - because there's no package for this version on pypi. remove me when we update it
-py==1.4.33
+multidict==4.3.0
+mysql-connector-python==8.0.11  # puppet: nodownload - because there's no package for this version on pypi. remove me when we update it
+py==1.5.3
 pyparsing==2.2.0
-python-dateutil==2.6.0
+python-dateutil==2.7.3
 PyYAML==3.12
 Represent==1.5.1
-requests==2.13.0
-six==1.10.0
+requests==2.18.4
+six==1.11.0
 slugid==1.0.7
-SQLAlchemy==1.1.7
-sqlalchemy-aio==0.11.0
-statsd==3.2.1
-taskcluster==1.2.0
-yarl==0.9.8
+SQLAlchemy==1.2.8
+sqlalchemy-aio==0.12.0
+statsd==3.2.2
+taskcluster==3.0.1
+yarl==1.2.4

--- a/modules/buildbot_bridge2/files/requirements.txt
+++ b/modules/buildbot_bridge2/files/requirements.txt
@@ -9,7 +9,7 @@ click==6.7
 jsonschema==2.6.0
 mohawk==0.3.4
 multidict==4.3.0
-mysql-connector-python==8.0.11  # puppet: nodownload - because there's no package for this version on pypi. remove me when we update it
+mysql-connector-python==8.0.11
 py==1.5.3
 pyparsing==2.2.0
 python-dateutil==2.7.3

--- a/modules/buildmaster/files/db_maintenance_requirements.txt
+++ b/modules/buildmaster/files/db_maintenance_requirements.txt
@@ -1,3 +1,3 @@
 # python_version: 27
-SQLAlchemy==1.2.7
+SQLAlchemy==1.2.8
 MySQL-python==1.2.5

--- a/modules/buildmaster/files/queue_requirements.txt
+++ b/modules/buildmaster/files/queue_requirements.txt
@@ -1,8 +1,8 @@
 # python_version: 27
 buildbot==0.8.4-pre-moz2  # pyup: ignore, puppet: nodownload
 MozillaPulse==1.3
-amqp==2.2.2
+amqp==2.3.2
 anyjson==0.3.3
-kombu==4.2.0
+kombu==4.2.1
 pytz==2018.4
 vine==1.1.4

--- a/modules/cruncher/files/allthethings_requirements.txt
+++ b/modules/cruncher/files/allthethings_requirements.txt
@@ -24,4 +24,4 @@ idna==2.6
 enum34==1.1.6
 ipaddress==1.0.22
 asn1crypto==0.24.0
-sqlalchemy==0.6.4
+sqlalchemy==1.2.8

--- a/modules/cruncher/files/slave_health_requirements.txt
+++ b/modules/cruncher/files/slave_health_requirements.txt
@@ -1,6 +1,6 @@
 # python_version: 27
 MySQL-python==1.2.5
-SQLAlchemy==1.2.7
+SQLAlchemy==1.2.8
 pytz==2018.4
 # Pinning to avoid investigating if an update would break
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1289822#c7

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -1,12 +1,12 @@
 # python_version: 27
 # install six before cryptography
 six==1.11.0
-Fabric==2.0.1
+Fabric==2.1.3
 Jinja2==2.10
 PGPy==0.4.3
 PyHawk-with-a-single-extra-commit==0.1.5
 PyYAML==3.12
-SQLAlchemy==1.2.7
+SQLAlchemy==1.2.8
 Tempita==0.5.2
 # don't upgrade twisted because it doesn't work with our buildbot
 Twisted==12.3.0  # pyup: ignore

--- a/modules/selfserve_agent/files/requirements.txt
+++ b/modules/selfserve_agent/files/requirements.txt
@@ -10,14 +10,14 @@ PasteDeploy==1.5.2
 PasteScript==2.0.2
 Pygments==2.2.0
 Pylons==1.0.3
-amqp==2.2.2
+amqp==2.3.2
 buildapi==0.3.25  # puppet: nodownload
 buildbot==0.8.4-pre-moz2  # pyup: ignore, puppet: nodownload
 decorator==4.2.1
-#distribute==0.7.3
-kombu==4.2.0
+distribute==0.7.3
+kombu==4.2.1
 Routes==2.4.1
-SQLAlchemy==1.2.7
+SQLAlchemy==1.2.8
 Tempita==0.5.2
 # don't upgrade twisted because it doesn't work with our buildbot
 Twisted==10.1.0  # pyup: ignore

--- a/modules/signingworker/files/requirements.txt
+++ b/modules/signingworker/files/requirements.txt
@@ -1,6 +1,6 @@
 # python_version: 27
 PyHawk-with-a-single-extra-commit==0.1.5
-amqp==2.2.2
+amqp==2.3.2
 anyjson==0.3.3
 argparse==1.4.0
 arrow==0.12.1
@@ -13,7 +13,7 @@ ecdsa==0.13
 functools32==3.2.3-2
 idna==2.6
 jsonschema==2.6.0
-kombu==4.2.0
+kombu==4.2.1
 mohawk==0.3.4
 pyasn1==0.4.3
 pycrypto==2.6.1

--- a/modules/slaveapi/files/requirements.txt
+++ b/modules/slaveapi/files/requirements.txt
@@ -1,5 +1,5 @@
 # python_version: 27
-gevent==1.3.1
+gevent==1.3.2.post0
 greenlet==0.4.13
 pycrypto==2.6.1
 # unused, but one of the vendor libraries (Flask) requires it
@@ -16,14 +16,14 @@ itsdangerous==0.24
 docopt==0.6.2
 python-daemon==2.1.2
 gevent_subprocess==0.1.2
-furl==1.0.1
+furl==1.0.2
 orderedmultidict==0.7.11
 pytz==2018.4
 python-dateutil==2.7.3
 # for aws cloud-tools
 MySQL-python==1.2.5
 PyYAML==3.12
-SQLAlchemy==1.2.7
+SQLAlchemy==1.2.8
 cfn-pyplates>=0.5.0
 ecdsa==0.13
 invtool==4.4  # puppet: nodownload
@@ -36,7 +36,7 @@ testtools==2.3.0
 pbr==4.0.3
 schema==0.6.7
 simplejson==3.15.0
-Fabric==2.0.1
+Fabric==2.1.3
 IPy==0.83
 argparse==1.4.0
 boto==2.48.0

--- a/modules/slaverebooter/files/requirements.txt
+++ b/modules/slaverebooter/files/requirements.txt
@@ -1,5 +1,5 @@
 # python_version: 27
-furl==1.0.1
+furl==1.0.2
 requests==2.18.4
 docopt==0.6.2
 buildtools==1.0.6


### PR DESCRIPTION
Most of this looks really safe - buildbot bridge2 has the most notable upgrade (big mysql-connector version change). If anything goes wrong with its upgrades, we can probably just rollback and not bother, since it dies with Buildbot.