### PR TITLE
Don't install distribute with selfserve_agent

### DIFF
--- a/modules/selfserve_agent/files/requirements.txt
+++ b/modules/selfserve_agent/files/requirements.txt
@@ -14,7 +14,6 @@ amqp==2.3.2
 buildapi==0.3.25  # puppet: nodownload
 buildbot==0.8.4-pre-moz2  # pyup: ignore, puppet: nodownload
 decorator==4.2.1
-distribute==0.7.3
 kombu==4.2.1
 Routes==2.4.1
 SQLAlchemy==1.2.8


### PR DESCRIPTION
It was replaced with setuptools a long time ago, which gets installed when the virtualenv is created.