### PR TITLE
Fix issues with bbb2.

### DIFF
--- a/modules/buildbot_bridge2/files/requirements.txt
+++ b/modules/buildbot_bridge2/files/requirements.txt
@@ -4,8 +4,10 @@ aiohttp==1.3.5  # pyup: ignore
 appdirs==1.4.3
 arrow==0.12.1
 async-timeout==3.0.0
+certifi==2018.4.16
 chardet==3.0.4
 click==6.7
+idna==2.6
 jsonschema==2.6.0
 mohawk==0.3.4
 multidict==4.3.0
@@ -21,5 +23,9 @@ slugid==1.0.7
 SQLAlchemy==1.2.8
 sqlalchemy-aio==0.12.0
 statsd==3.2.2
-taskcluster==3.0.1
-yarl==1.2.4
+# Held at 1.2.0 to avoid needing to upgrade aiohttp
+taskcluster==1.2.0  # pyup: ignore
+# Held at 1.22 because that's what requests requires
+urllib3==1.22  # pyup: ignore
+# Held at 0.9.8 because that's what our aiohttp requires
+yarl==0.9.8  # pyup: ignore

--- a/modules/buildbot_bridge2/manifests/init.pp
+++ b/modules/buildbot_bridge2/manifests/init.pp
@@ -11,7 +11,7 @@ class buildbot_bridge2 {
 
     $bbb_version = $::buildbot_bridge2::settings::env_config['version']
     $external_packages = file("buildbot_bridge2/requirements.txt")
-    $packages = "${external_requirements}\nbbb==${bbb_version}"
+    $packages = "${external_packages}\nbbb==${bbb_version}"
 
     # If the Python installation changes, we need to rebuild the virtualenv
     # from scratch. Before doing that, we need to stop the running instance.


### PR DESCRIPTION
I noticed that none of the upgrades were happening, which was because of the typo in the manifest, and then when the upgrades did happen, we had some bustage rooted in the Taskcluster upgrade. I've pinned the necessary packages to hold things at stable versions.