### PR TITLE
Bug 1467002 - urllib3 missing from releaserunner virtualenv

### DIFF
--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -34,5 +34,6 @@ slugid==1.0.7
 sqlalchemy-migrate==0.11.0
 taskcluster==3.0.1
 toposort==1.5
+urllib3==1.22
 wsgiref==0.1.2
 zope.interface==4.5.0


### PR DESCRIPTION
Looks like urllib3 was missing from the requirements.txt for releaserunner when it was first implemented in f5a07cb7e4338ebc187b8bcdc709a02c098e4b90. We have urllib3 in modules/releaserunner3/files/requirements.txt already, so we didn't hit any bustage there. 