### PR TITLE
Bug 1467067 - ESR52 signing issues with int values for Content-Length

### DIFF
--- a/modules/signingworker/files/requirements.txt
+++ b/modules/signingworker/files/requirements.txt
@@ -20,7 +20,7 @@ pycrypto==2.6.1
 python-dateutil==2.7.3
 python-jose==3.0.0
 redo==1.6
-requests==2.18.4
+requests==2.10.0
 rsa==3.4.2
 sh==1.12.14
 signingworker==0.15

--- a/modules/signingworker/files/requirements.txt
+++ b/modules/signingworker/files/requirements.txt
@@ -23,7 +23,8 @@ redo==1.6
 requests==2.10.0
 rsa==3.4.2
 sh==1.12.14
-signingworker==0.15
+# see bug 1467067
+signingworker==0.15  # pyup: ignore
 six==1.11.0
 slugid==1.0.7
 taskcluster==3.0.1

--- a/modules/signingworker/files/requirements.txt
+++ b/modules/signingworker/files/requirements.txt
@@ -20,11 +20,11 @@ pycrypto==2.6.1
 python-dateutil==2.7.3
 python-jose==3.0.0
 redo==1.6
-requests==2.10.0
+# see bug 1467067
+requests==2.10.0  # pyup: ignore
 rsa==3.4.2
 sh==1.12.14
-# see bug 1467067
-signingworker==0.15  # pyup: ignore
+signingworker==0.15
 six==1.11.0
 slugid==1.0.7
 taskcluster==3.0.1


### PR DESCRIPTION
[Bug 1467067](https://bugzilla.mozilla.org/show_bug.cgi?id=1467067) for more details - tl;dr is that current requests doesn't like the headers we give it for partial and source signing.

This can be a temporary downgrade until https://github.com/taskcluster/taskcluster-client.py/issues/107 is resolved by a new release there.