### PR TITLE
Upgrade as much of releasetasks as we can

### DIFF
--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -1,37 +1,46 @@
 # python_version: 27
 # install six before cryptography
-six==1.9.0
-Fabric==1.5.1
-Jinja2==2.6
-PGPy==0.3.0
+six==1.11.0
+Fabric==2.1.3
+Jinja2==2.10
+PGPy==0.4.3
 PyHawk-with-a-single-extra-commit==0.1.5
-PyYAML==3.10
-SQLAlchemy==0.8.0b2
-Tempita==0.5.1
-Twisted==12.3.0
-arrow==0.5.4
-buildbot==0.8.7p1
-certifi==0.0.8
+PyYAML==3.12
+SQLAlchemy==1.2.8
+Tempita==0.5.2
+# don't upgrade twisted because it doesn't work with our buildbot
+Twisted==12.3.0  # pyup: ignore
+arrow==0.12.1
+asn1crypto==0.24.0
+bcrypt==3.1.4
+buildbot==0.8.7p1  # pyup: ignore, puppet: nodownload
+certifi==2018.4.16
+cffi==1.11.5
+chardet==3.0.4
 chunkify==1.2
-cryptography==0.6
-decorator==3.4.0
-ecdsa==0.10
-enum34==1.0.4
-futures==3.1.1
-mohawk==0.3.1
-paramiko==1.9.0
+cryptography==2.2.2
+decorator==4.2.1
+ecdsa==0.13
+enum34==1.1.6
+futures==3.2.0
+idna==2.6
+ipaddress==1.0.22
+mohawk==0.3.4
+paramiko==2.4.1
 pycrypto==2.6.1
-python-dateutil==1.5
-python-jose==0.5.2
-redo==1.5
-releasetasks==0.3.3
-requests==2.6.0
+pynacl==1.2.1
+python-dateutil==2.7.3
+python-jose==3.0.0
+redo==1.6
+releasetasks==0.4.0  # puppet: nodownload
+requests==2.18.4
 requests-hawk==1.0.0
-simplejson==2.6.2
+simplejson==3.15.0
 singledispatch==3.4.0.3
 slugid==1.0.7
-sqlalchemy-migrate==0.7.2
-taskcluster==0.0.24
+sqlalchemy-migrate==0.11.0
+taskcluster==3.0.1
 toposort==1.5
+urllib3==1.22
 wsgiref==0.1.2
-zope.interface==4.0.2
+zope.interface==4.5.0

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -40,7 +40,8 @@ simplejson==3.15.0
 singledispatch==3.4.0.3
 slugid==1.0.7
 sqlalchemy-migrate==0.11.0
-taskcluster==3.0.1
+# Held at this ancient version because we need encrypted enviroment variable support.
+taskcluster==0.0.24  # pyup: noupdate
 toposort==1.5
 urllib3==1.22
 wsgiref==0.1.2

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -1,6 +1,7 @@
 # python_version: 27
 # install six before cryptography
-six==1.11.0
+# held at old version because 1.11.0 breaks pgpy
+six==1.10.0  # pyup: ignore
 Fabric==2.1.3
 Jinja2==2.10
 PGPy==0.4.3
@@ -28,6 +29,7 @@ idna==2.6
 ipaddress==1.0.22
 mohawk==0.3.4
 paramiko==2.4.1
+pyasn1==0.4.3
 pycrypto==2.6.1
 pynacl==1.2.1
 python-dateutil==2.7.3

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -12,6 +12,7 @@ Tempita==0.5.2
 Twisted==12.3.0  # pyup: ignore
 arrow==0.12.1
 asn1crypto==0.24.0
+backports.functools_lru_cache==1.5
 bcrypt==3.1.4
 buildbot==0.8.7p1  # pyup: ignore, puppet: nodownload
 certifi==2018.4.16

--- a/modules/releaserunner/files/requirements.txt
+++ b/modules/releaserunner/files/requirements.txt
@@ -32,7 +32,7 @@ pynacl==1.2.1
 python-dateutil==2.7.3
 python-jose==3.0.0
 redo==1.6
-releasetasks==0.4.0  # puppet: nodownload
+releasetasks==0.4.1  # puppet: nodownload
 requests==2.18.4
 requests-hawk==1.0.0
 simplejson==3.15.0

--- a/modules/releaserunner/manifests/services.pp
+++ b/modules/releaserunner/manifests/services.pp
@@ -15,4 +15,12 @@ class releaserunner::services {
                               Mercurial::Repo['releaserunner-tools']],
             extra_config => template("${module_name}/extra_config.erb")
     }
+
+    exec {
+        'restart-releaserunner':
+            command     => '/usr/bin/supervisorctl restart releaserunner',
+            refreshonly => true,
+            subscribe   => [Python::Virtualenv[$releaserunner::settings::root],
+                            File["${releaserunner::settings::root}/${config::releaserunner_env_config[$releaserunner_env]['releaserunner_config_file']}"]];
+    }
 }


### PR DESCRIPTION
I tested this on bm83 as much as possible (I had to hack out a bunch of checks to get as far as task submission). Notable problems/fixes:
* The latest taskcluster library doesn't support encrypted vars
* Had to install pyasn1 for pgpy
* Had to downgrade "six" for pgpy to work (see https://github.com/SecurityInnovation/PGPy/issues/217)

In the end, I was able to get a graph created. I can't guarantee 100% that this will work in production because of all the hacks that I did, but I think this is as well tested as it's going to get.