### PR TITLE
Bug 1491454: write collectd logs from aws hosts to mdc1 graphite

### DIFF
--- a/manifests/moco-config.pp
+++ b/manifests/moco-config.pp
@@ -356,7 +356,7 @@ class config inherits config::base {
     $buildmaster_ssh_keys              = [ 'ffxbld_rsa', 'tbirdbld_dsa', 'trybld_dsa' ]
 
     case $::fqdn {
-        /.*\.mdc1\.mozilla\.com/: {
+        /.*\.(mdc1|use1|usw2)\.mozilla\.com/: {
                 $collectd_write = {
                     graphite_nodes => {
                         'graphite1.private.mdc1.mozilla.com' => {


### PR DESCRIPTION
Right now, there are no defaults for writing collectd to graphite in AWS .   This directs ec2 hosts in use1 and usw2 to send collectd to mdc1 graphite.